### PR TITLE
fix: Clear input fields when closing dialogs

### DIFF
--- a/apps/web/src/components/common/sidebar/sections/projects/create-project-modal.tsx
+++ b/apps/web/src/components/common/sidebar/sections/projects/create-project-modal.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import icons from "@/constants/project-icons";
@@ -10,6 +9,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 type CreateProjectModalProps = {
   open: boolean;

--- a/apps/web/src/components/common/sidebar/sections/projects/create-project-modal.tsx
+++ b/apps/web/src/components/common/sidebar/sections/projects/create-project-modal.tsx
@@ -9,7 +9,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 
 type CreateProjectModalProps = {
   open: boolean;
@@ -30,8 +30,6 @@ function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   });
   const IconComponent = icons[selectedIcon as keyof typeof icons];
   const navigate = useNavigate();
-
-  const projectNameRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -74,14 +72,6 @@ function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
     onClose();
   };
 
-  useEffect(() => {
-    if (open) {
-      requestAnimationFrame(() => {
-        projectNameRef.current?.focus();
-      });
-    }
-  }, [open]);
-
   return (
     <Dialog.Root open={open} onOpenChange={resetAndCloseModal}>
       <Dialog.Portal>
@@ -92,7 +82,10 @@ function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
               <Dialog.Title className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                 New Project
               </Dialog.Title>
-              <Dialog.Close className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300">
+              <Dialog.Close
+                asChild
+                className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+              >
                 <X size={20} />
               </Dialog.Close>
             </div>
@@ -107,7 +100,6 @@ function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
                   Project Name
                 </label>
                 <Input
-                  ref={projectNameRef}
                   value={name}
                   onChange={handleNameChange}
                   placeholder="Designers"

--- a/apps/web/src/components/common/sidebar/sections/workspaces/components/create-workspace-modal.tsx
+++ b/apps/web/src/components/common/sidebar/sections/workspaces/components/create-workspace-modal.tsx
@@ -5,7 +5,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 
 interface CreateWorkspaceModalProps {
   open: boolean;
@@ -20,8 +20,6 @@ export function CreateWorkspaceModal({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { mutateAsync } = useCreateWorkspace({ name });
-
-  const workspaceInputRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -48,14 +46,6 @@ export function CreateWorkspaceModal({
     onClose();
   };
 
-  useEffect(() => {
-    if (open) {
-      requestAnimationFrame(() => {
-        workspaceInputRef.current?.focus();
-      });
-    }
-  }, [open]);
-
   return (
     <Dialog.Root open={open} onOpenChange={resetAndCloseModal}>
       <Dialog.Portal>
@@ -66,7 +56,10 @@ export function CreateWorkspaceModal({
               <Dialog.Title className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                 New Workspace
               </Dialog.Title>
-              <Dialog.Close className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300">
+              <Dialog.Close
+                asChild
+                className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+              >
                 <X size={20} />
               </Dialog.Close>
             </div>
@@ -81,12 +74,12 @@ export function CreateWorkspaceModal({
                   Workspace Name
                 </label>
                 <Input
-                  ref={workspaceInputRef}
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="My Workspace"
                   className="bg-white dark:bg-zinc-800/50"
                   required
+                  autoFocus
                 />
               </div>
 

--- a/apps/web/src/components/common/sidebar/sections/workspaces/components/create-workspace-modal.tsx
+++ b/apps/web/src/components/common/sidebar/sections/workspaces/components/create-workspace-modal.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import useCreateWorkspace from "@/hooks/queries/workspace/use-create-workspace";
@@ -6,6 +5,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 interface CreateWorkspaceModalProps {
   open: boolean;

--- a/apps/web/src/components/team/invite-team-member-modal.tsx
+++ b/apps/web/src/components/team/invite-team-member-modal.tsx
@@ -51,7 +51,9 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
   };
 
   const resetInviteTeamMember = async () => {
-    await queryClient.invalidateQueries({ queryKey: ["workspace-users"] });
+    await queryClient.invalidateQueries({
+      queryKey: ["workspace-users", workspaceId],
+    });
     form.reset();
   };
 

--- a/apps/web/src/components/team/invite-team-member-modal.tsx
+++ b/apps/web/src/components/team/invite-team-member-modal.tsx
@@ -4,7 +4,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
-import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "../ui/button";
@@ -34,8 +33,6 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
   const queryClient = useQueryClient();
   const { workspaceId } = Route.useParams();
 
-  const emailRef = useRef<HTMLInputElement>(null);
-
   const form = useForm<TeamMemberFormValues>({
     resolver: zodResolver(teamMemberSchema),
     defaultValues: {
@@ -63,14 +60,6 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
     onClose();
   };
 
-  useEffect(() => {
-    if (open) {
-      requestAnimationFrame(() => {
-        emailRef.current?.focus();
-      });
-    }
-  }, [open]);
-
   return (
     <Dialog.Root open={open} onOpenChange={resetAndCloseModal}>
       <Dialog.Portal>
@@ -81,7 +70,10 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
               <Dialog.Title className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                 Invite Team Member
               </Dialog.Title>
-              <Dialog.Close className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300">
+              <Dialog.Close
+                asChild
+                className="text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+              >
                 <X size={20} />
               </Dialog.Close>
             </div>
@@ -101,12 +93,9 @@ function InviteTeamMemberModal({ open, onClose }: Props) {
                           <FormControl>
                             <Input
                               {...field}
-                              ref={(e) => {
-                                field.ref(e);
-                                emailRef.current = e;
-                              }}
                               placeholder="colleague@company.com"
                               className="bg-white dark:bg-zinc-800/50"
+                              autoFocus
                             />
                           </FormControl>
                           <FormMessage />

--- a/apps/web/src/components/team/invite-team-member-modal.tsx
+++ b/apps/web/src/components/team/invite-team-member-modal.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef } from "react";
 import useInviteWorkspaceUser from "@/hooks/mutations/workspace-user/use-invite-workspace-user";
 import { Route } from "@/routes/dashboard/teams/$workspaceId/_layout";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
+import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "../ui/button";


### PR DESCRIPTION
Changes Made:

Issue #79 

1. State reset on modal close:

Ensured that the modal state is reset when the modal is closed. This prevents unintended behavior by clearing any previous input or selections, providing a fresh start each time the modal is opened.

2. Input focus:

Implemented focus management to automatically focus the first input field when the modal is opened. This enhances the user experience by allowing users to start interacting with the modal immediately without needing to manually click on the input field.